### PR TITLE
Spark 3.5: Added backticks around column names in the generated DSL to support special characters by default

### DIFF
--- a/.github/workflows/quenya-dsl-githubactions.yml
+++ b/.github/workflows/quenya-dsl-githubactions.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   Build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:13.4

--- a/src/main/scala/com/github/music/of/the/ainur/quenya/QuenyaDSL.scala
+++ b/src/main/scala/com/github/music/of/the/ainur/quenya/QuenyaDSL.scala
@@ -30,10 +30,10 @@ object QuenyaDSL extends CombinatorParser with SparkCodeGenerator with Serializa
       dataType match {
         case  fieldType @ (BinaryType | FloatType | ByteType 
 | IntegerType | LongType | BooleanType | StringType |
-            TimestampType | DoubleType | ShortType) => dslBuilder += s"""`${fieldGen(fields,precedence)}`$$`${aliasGen(fields,shortName)}`:${fieldType.toString}"""
+            TimestampType | DoubleType | ShortType) => dslBuilder += s"""${fieldGen(fields,precedence)}`${fields.mkString(".")}`$$`${aliasGen(fields,shortName)}`:${fieldType.toString}"""
         case ArrayType(dt,_) => {
           val alias = aliasGen(fields,shortName)
-          dslBuilder += s"""`${fieldGen(fields,precedence)}`@`$alias`"""
+          dslBuilder += s"""${fieldGen(fields,precedence)}`${fields.mkString(".")}`@`$alias`"""
           generator(name,dt, List(alias), precedence + 1,dslBuilder = dslBuilder)
         }
         case StructType(fieldsStruct) => fieldsStruct.map(fd => generator(fd.name,fd.dataType,fields :+ fd.name,precedence,dslBuilder = dslBuilder))
@@ -47,5 +47,5 @@ object QuenyaDSL extends CombinatorParser with SparkCodeGenerator with Serializa
       fields.mkString("_")
 
   private def fieldGen(fields: List[String],precedence: Int): String =
-    (0 until precedence).map(_ => "\t").mkString + fields.mkString(".")
+    (0 until precedence).map(_ => "\t").mkString
 }

--- a/src/main/scala/com/github/music/of/the/ainur/quenya/QuenyaDSL.scala
+++ b/src/main/scala/com/github/music/of/the/ainur/quenya/QuenyaDSL.scala
@@ -30,10 +30,10 @@ object QuenyaDSL extends CombinatorParser with SparkCodeGenerator with Serializa
       dataType match {
         case  fieldType @ (BinaryType | FloatType | ByteType 
 | IntegerType | LongType | BooleanType | StringType |
-            TimestampType | DoubleType | ShortType) => dslBuilder += s"""${fieldGen(fields,precedence)}$$${aliasGen(fields,shortName)}:${fieldType.toString}"""
+            TimestampType | DoubleType | ShortType) => dslBuilder += s"""`${fieldGen(fields,precedence)}`$$`${aliasGen(fields,shortName)}`:${fieldType.toString}"""
         case ArrayType(dt,_) => {
           val alias = aliasGen(fields,shortName)
-          dslBuilder += s"""${fieldGen(fields,precedence)}@$alias"""
+          dslBuilder += s"""`${fieldGen(fields,precedence)}`@`$alias`"""
           generator(name,dt, List(alias), precedence + 1,dslBuilder = dslBuilder)
         }
         case StructType(fieldsStruct) => fieldsStruct.map(fd => generator(fd.name,fd.dataType,fields :+ fd.name,precedence,dslBuilder = dslBuilder))

--- a/src/test/scala/com/github/music/of/the/ainur/quenya/Test.scala
+++ b/src/test/scala/com/github/music/of/the/ainur/quenya/Test.scala
@@ -53,9 +53,6 @@ class Test extends AnyFunSuite with BeforeAndAfter {
 `weapon`@`weapon`
 	`weapon`$`weapon`:StringType"""
 
-  println("##########")
-  println(quenyaDsl.getDsl(df))
-  println("##########")
   test("Test for DSL Generate") {
     assert(dslMatch == quenyaDsl.getDsl(df))
   }

--- a/src/test/scala/com/github/music/of/the/ainur/quenya/Test.scala
+++ b/src/test/scala/com/github/music/of/the/ainur/quenya/Test.scala
@@ -53,6 +53,9 @@ class Test extends AnyFunSuite with BeforeAndAfter {
 `weapon`@`weapon`
 	`weapon`$`weapon`:StringType"""
 
+  println("##########")
+  println(quenyaDsl.getDsl(df))
+  println("##########")
   test("Test for DSL Generate") {
     assert(dslMatch == quenyaDsl.getDsl(df))
   }

--- a/src/test/scala/com/github/music/of/the/ainur/quenya/Test.scala
+++ b/src/test/scala/com/github/music/of/the/ainur/quenya/Test.scala
@@ -44,14 +44,14 @@ class Test extends AnyFunSuite with BeforeAndAfter {
 
   // Test case for getDsl method
   val dslMatch =
-    """age$age:LongType
-name.LastName$LastName:StringType
-name.nameOne$nameOne:StringType
-name.nickNames@nickNames
-	nickNames$nickNames:StringType
-race$race:StringType
-weapon@weapon
-	weapon$weapon:StringType"""
+    """`age`$`age`:LongType
+`name.LastName`$`LastName`:StringType
+`name.nameOne`$`nameOne`:StringType
+`name.nickNames`@`nickNames`
+	`nickNames`$`nickNames`:StringType
+`race`$`race`:StringType
+`weapon`@`weapon`
+	`weapon`$`weapon`:StringType"""
 
   test("Test for DSL Generate") {
     assert(dslMatch == quenyaDsl.getDsl(df))


### PR DESCRIPTION
@mantovani 